### PR TITLE
Fix: replace undefined self.path with self.src_path in process()

### DIFF
--- a/src/utils/media_processor.py
+++ b/src/utils/media_processor.py
@@ -153,9 +153,9 @@ class MediaProcessor:
         results = []
         # Processed according to the path type
         if os.path.isfile(self.src_path):
-            if self.path.lower().endswith(self.image_suffix):
+            if self.src_path.lower().endswith(self.image_suffix):
                 results.append(self.process_image(self.src_path, show, save))
-            elif self.path.lower().endswith(self.video_suffix):
+            elif self.src_path.lower().endswith(self.video_suffix):
                 results.append(self.process_video(self.src_path, show, save))
         elif os.path.isdir(self.src_path):
             return self.process_directory(self.src_path, show, save)


### PR DESCRIPTION
### Problem
The method `process()` in `src/utils/media_processor.py` uses `self.path`, which is not defined anywhere.  
This causes a runtime error when processing a single image file.

### Fix
Replaced `self.path` with `self.src_path` in `process()`.  
Single image inference now works correctly in `scripts/test`.

### Impact
- Fixes `AttributeError` for single image input.
- Makes `process()` in `media_processor.py` consistent with the rest of the codebase.
